### PR TITLE
editor: Editor: Add missing removeInclude() function

### DIFF
--- a/editor/js/Editor.js
+++ b/editor/js/Editor.js
@@ -184,6 +184,19 @@ Editor.prototype = {
 
 	},
 
+	removeInclude: function ( include ) {
+
+		var index = this.includes.indexOf( include );
+
+		this.includes.splice( index, 1 );
+
+		var script = document.getElementById( 'include-' + index );
+		document.head.removeChild( script );
+
+		this.signals.includeRemoved.dispatch();
+
+	},
+
 	selectInclude: function ( include ) {
 
 		this.signals.includeSelected.dispatch( include );


### PR DESCRIPTION
The editor allows to remove scripts from the project, but the REMOVE
button is broken because removeInclude() function is undefined. Let's
fix this.