### PR TITLE
editor: Menubar.File: Add Import menu option

### DIFF
--- a/editor/js/Menubar.File.js
+++ b/editor/js/Menubar.File.js
@@ -34,6 +34,37 @@ Menubar.File = function ( editor ) {
 	} );
 	options.add( option );
 
+	// import
+
+	var option = new UI.Panel();
+	option.setClass( 'option' );
+	option.setTextContent( 'Import' );
+	option.onClick( Import );
+	options.add( option );
+
+	var fileInput = document.createElement( 'input' );
+	fileInput.type = 'file';
+	fileInput.addEventListener( 'change', function ( event ) {
+
+		var reader = new FileReader();
+		reader.addEventListener( 'load', function ( event ) {
+
+			editor.clear();
+			editor.fromJSON( JSON.parse( event.target.result ) );
+
+		}, false );
+
+		reader.readAsText( fileInput.files[ 0 ] );
+
+	} );
+
+	function Import () {
+
+		if ( confirm( 'Any unsaved data will be lost. Are you sure?' ) )
+			fileInput.click();
+
+	}
+
 	// export
 
 	var option = new UI.Panel();


### PR DESCRIPTION
File menu already has an Export option to save the session in JSON format.
It'd be nice to have an Import option to simply load a previously exported session, and this PR adds support for that.