### PR TITLE
Microsoft Edge Requires a Default Value for Button UI

### DIFF
--- a/editor/js/libs/ui.js
+++ b/editor/js/libs/ui.js
@@ -933,7 +933,7 @@ UI.Button = function ( value ) {
 	dom.className = 'Button';
 
 	this.dom = dom;
-	this.dom.textContent = value;
+	this.dom.textContent = value || '';
 
 	return this;
 


### PR DESCRIPTION
![capture](https://user-images.githubusercontent.com/220033/40212113-2641957a-5a03-11e8-876f-25b94f61e004.PNG)

When creating a new `Button` sometimes there aren't any arguments passed. This creates the `UNDEFINED` string seen in the screenshot above in Microsoft Edge.