### PR TITLE
Show Loops in Editor

### DIFF
--- a/editor/js/Timeline.js
+++ b/editor/js/Timeline.js
@@ -184,6 +184,16 @@ var Timeline = function ( editor ) {
 
 	//
 
+	var loopMark = document.createElement( 'div' );
+	loopMark.style.position = 'absolute';
+	loopMark.style.top = 0;
+	loopMark.style.left = - 8 + 'px';
+	loopMark.style.height = 100 + '%';
+	loopMark.style.width = 0;
+	loopMark.style.background = 'rgba( 255, 255, 255, 0.1 )';
+	loopMark.style.pointerEvents = 'none';
+	timeline.dom.appendChild( loopMark );
+
 	var timeMark = document.createElement( 'div' );
 	timeMark.style.position = 'absolute';
 	timeMark.style.top = '0px';
@@ -197,6 +207,18 @@ var Timeline = function ( editor ) {
 	function updateTimeMark() {
 
 		timeMark.style.left = ( player.currentTime * scale ) - scroller.scrollLeft - 8 + 'px';
+
+		var loop = player.getLoop();
+		if ( !loop || loop.length <= 0 ) {
+			loopMark.style.width = 0;
+			return;
+		}
+
+		var x1 = loop[ 0 ] * scale;
+		var x2 = loop[ 1 ] * scale;
+
+		loopMark.style.width = Math.max( x1, x2 ) - Math.min( x1, x2 ) + 'px';
+		loopMark.style.left = Math.min( x1, x2 ) - scroller.scrollLeft + 'px';
 
 	}
 

--- a/src/Frame.js
+++ b/src/Frame.js
@@ -48,6 +48,9 @@ var FRAME = {
 				}
 				audio = value;
 			},
+			getLoop: function () {
+				return loop;
+			},
 			setLoop: function ( value ) {
 				loop = value;
 			},


### PR DESCRIPTION
![capture](https://user-images.githubusercontent.com/220033/40213740-ec3ceb1e-5a0b-11e8-88e5-9d1922b5cce6.PNG)

If you set the `player.setLoop( [ startTime, endTime ] );` then the editor will show a highlighted area in the timeline for it. Maybe there's a better spot to update the styling of the marker rather than when the `timeMark` is updated?

I'm not sure where the best place for the style update is... 😅 