### PR TITLE
Includes Executed on FRAME.Timeline.compile

### DIFF
--- a/src/Frame.js
+++ b/src/Frame.js
@@ -254,6 +254,7 @@ var FRAME = {
 
 	Timeline: function () {
 
+		var includes = [];
 		var effects = [];
 
 		var animations = [];
@@ -337,17 +338,17 @@ var FRAME = {
 
 				this.loadLibraries( libraries, function () {
 
+					// Includes
+
 					for ( var i = 0; i < json.includes.length; i ++ ) {
 
 						var data = json.includes[ i ];
+						var name = data[ 0 ];
 						var source = data[ 1 ];
 
 						if ( Array.isArray( source ) ) source = source.join( '\n' );
 
-						var script = document.createElement( 'script' );
-						script.id = 'library-' + i;
-						script.textContent = '( function () { ' + source + '} )()';
-						document.head.appendChild( script );
+						includes.push( new FRAME.Effect( name, source ) );
 
 					}
 
@@ -394,6 +395,18 @@ var FRAME = {
 			compile: function ( resources, player ) {
 
 				var animations = this.animations;
+
+				for ( var i = 0, l = includes.length; i < l; i++ ) {
+
+					var include = includes[ i ];
+
+					if ( include.program === null ) {
+
+						include.compile( resources, player );
+
+					}
+
+				}
 
 				for ( var i = 0, l = animations.length; i < l; i ++ ) {
 


### PR DESCRIPTION
When creating multiple `FRAME.Timeline`s it becomes tricky to manage Includes. Not only do they rely on a global `resources` variable to be defined, the `library-id` overlaps between instances. I followed the general use pattern that the Editor uses to invoke Includes. Then I create and invoke their programs under the `FRAME.Timeline.compile` instead of on `FRAME.Timeline.load` so that each script has access to the `resources` and `player` variables.