### PR TITLE
Fixed exception when modifying custom parameter from sidebar

### DIFF
--- a/editor/js/Sidebar.Animation.js
+++ b/editor/js/Sidebar.Animation.js
@@ -20,6 +20,7 @@ Sidebar.Animation = function ( editor ) {
 
 		var parameterRow = new UI.Row();
 		parameterRow.add( new UI.Text( parameter.name ).setWidth( '90px' ) );
+		var animation = editor.selected;
 
 		if ( parameter instanceof FRAME.Parameters.Boolean ) {
 


### PR DESCRIPTION
The parameter animation was not defined inside createParameterRow and
falsely pointed to the animation tab (dom element) instead of to the
selected timeline block.