### PR TITLE
Changed timeline to scroll in play mode

### DIFF
--- a/editor/js/Timeline.js
+++ b/editor/js/Timeline.js
@@ -204,10 +204,19 @@ var Timeline = function ( editor ) {
 	timeMark.style.pointerEvents = 'none';
 	timeline.dom.appendChild( timeMark );
 
+	var timelineWidth;
+	setTimeout(function() {
+		timelineWidth = timeline.dom.offsetWidth - 8;
+	}, 200);
+	
 	function updateTimeMark() {
-
-		timeMark.style.left = ( player.currentTime * scale ) - scroller.scrollLeft - 8 + 'px';
-
+		var offsetLeft = (player.currentTime * scale) - scroller.scrollLeft - 8;
+		timeMark.style.left = offsetLeft + 'px';
+		
+		// Auto-scroll if end is reached
+		if (editor.player.isPlaying && offsetLeft > timelineWidth) scroller.scrollLeft += timelineWidth;
+		
+		
 		// TODO Optimise this
 
 		var loop = player.getLoop();


### PR DESCRIPTION
This commit changes the timeline in play mode to scroll as soon as the red time mark reaches the right side of the visible area, making it easier to see which animations are currently played.

This is one of my changes to make frame.js behave more like a classic video editor. I don't know if this is what you want, so feel free to ignore the pull request if your don't like the change :)